### PR TITLE
Add new mbed-os features to mbedignore

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -13,6 +13,9 @@ mbed-os/features/FEATURE_COMMON_PAL/nanostack-libservice/source/*
 mbed-os/features/FEATURE_COMMON_PAL/nanostack-libservice/test/*
 mbed-os/features/FEATURE_UVISOR/*
 mbed-os/features/nanostack/*
+mbed-os/features/cellular/*
+mbed-os/features/lorawan/*
+mbed-os/features/nvstore/*
 mbed-os/features/netsocket/*
 mbed-os/features/storage/*
 mbed-os/features/filesystem/littlefs/*


### PR DESCRIPTION
This PR is an update allowing compiling with mbed-os 5.8