### PR TITLE
Support Nuvoton targets

### DIFF
--- a/NuMaker-mbed-SD-driver.lib
+++ b/NuMaker-mbed-SD-driver.lib
@@ -1,0 +1,1 @@
+https://github.com/OpenNuvoton/NuMaker-mbed-SD-driver/#5728cbcc12378c2ffba6e3a4035ce2ad3d6ceec9

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -205,6 +205,69 @@
               "PAL_USE_HW_RTC=0",
               "PAL_INT_FLASH_NUM_SECTIONS=2"
             ]
+        },
+        "NUMAKER_PFM_NUC472": {
+            "flash-start-address"               : "0x0",
+            "flash-size"                        : "(512*1024)",
+            "nvstore.area_1_address"            : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x11000)",
+            "nvstore.area_1_size"               : "0x1000",
+            "nvstore.area_2_address"            : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x12000)",
+            "nvstore.area_2_size"               : "0x1000",
+            "update-client.application-details" : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x13000)",
+            "application-start-address"         : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x14000)",
+            "max-application-size"              : "DEFAULT_MAX_APPLICATION_SIZE",
+
+            "update-client.storage-address"     : "(1024*1024*480)",
+            "update-client.storage-size"        : "(1024*1024*2)",
+
+            "target.macros_add": [
+                "PAL_INT_FLASH_NUM_SECTIONS=2",
+                "PAL_USE_INTERNAL_FLASH=1",
+                "PAL_USE_HW_ROT=0",
+                "PAL_USE_HW_RTC=1"
+            ]
+        },
+        "NUMAKER_PFM_M487": {
+            "flash-start-address"               : "0x0",
+            "flash-size"                        : "(512*1024)",
+            "nvstore.area_1_address"            : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x11000)",
+            "nvstore.area_1_size"               : "0x1000",
+            "nvstore.area_2_address"            : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x12000)",
+            "nvstore.area_2_size"               : "0x1000",
+            "update-client.application-details" : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x13000)",
+            "application-start-address"         : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x14000)",
+            "max-application-size"              : "DEFAULT_MAX_APPLICATION_SIZE",
+
+            "update-client.storage-address"     : "(1024*1024*480)",
+            "update-client.storage-size"        : "(1024*1024*2)",
+
+            "target.macros_add": [
+                "PAL_INT_FLASH_NUM_SECTIONS=2",
+                "PAL_USE_INTERNAL_FLASH=1",
+                "PAL_USE_HW_ROT=0",
+                "PAL_USE_HW_RTC=1"
+            ]
+        },
+        "NUMAKER_IOT_M487": {
+            "flash-start-address"               : "0x0",
+            "flash-size"                        : "(512*1024)",
+            "nvstore.area_1_address"            : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x11000)",
+            "nvstore.area_1_size"               : "0x1000",
+            "nvstore.area_2_address"            : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x12000)",
+            "nvstore.area_2_size"               : "0x1000",
+            "update-client.application-details" : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x13000)",
+            "application-start-address"         : "(MBED_CONF_APP_FLASH_START_ADDRESS+0x14000)",
+            "max-application-size"              : "DEFAULT_MAX_APPLICATION_SIZE",
+
+            "update-client.storage-address"     : "(1024*1024*480)",
+            "update-client.storage-size"        : "(1024*1024*2)",
+
+            "target.macros_add": [
+                "PAL_INT_FLASH_NUM_SECTIONS=2",
+                "PAL_USE_INTERNAL_FLASH=1",
+                "PAL_USE_HW_ROT=0",
+                "PAL_USE_HW_RTC=1"
+            ]
         }
     }
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -63,6 +63,12 @@ extern ARM_UC_PAAL_UPDATE MBED_CLOUD_CLIENT_UPDATE_STORAGE;
 #endif
 
 #if defined(ARM_UC_USE_PAL_BLOCKDEVICE) && (ARM_UC_USE_PAL_BLOCKDEVICE==1)
+#if defined(TARGET_NUVOTON)
+/* initialise sd card blockdevice */
+#include "NuSDBlockDevice.h"
+
+NuSDBlockDevice sd;
+#else
 #include "SDBlockDevice.h"
 
 /* initialise sd card blockdevice */
@@ -73,6 +79,7 @@ SDBlockDevice sd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO,
 #else
 SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO,
                  MBED_CONF_SD_SPI_CLK,  MBED_CONF_SD_SPI_CS);
+#endif
 #endif
 
 BlockDevice *arm_uc_blockdevice = &sd;


### PR DESCRIPTION
### Description

This PR tries to support mbed cloud bootloader on Nuvoton targets. It has the following modifications:
1.  Support **NUMAKER_PFM_NUC472**/**NUMAKER_PFM_M487**/**NUMAKER_IOT_M487** targets
1.  Replace sd-driver (SD card in SPI bus mode) with NuMaker-mbed-SD-driver.lib
    (SD card in SD bus mode) for storage on Nuvoton targets
