### PR TITLE
supporting SPIF for mbed connect cloud board (Ublox EVK Odin W2)

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -21,7 +21,6 @@ mbed-os/features/filesystem/littlefs/*
 mbed-os/features/filesystem/fat/*
 mbed-os/features/device_key/*
 mbed-os/components/wifi/*
-mbed-os/components/storage/*
 mbed-os/features/frameworks/mbed-client-cli/*
 mbed-os/features/lwipstack/*
 mbed-os/features/nfc/*
@@ -33,8 +32,6 @@ mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX
 mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
 mbed-os/features/frameworks/mbed-client-randlib/*
 mbed-os/features/frameworks/mbed-coap/*
-mbed-os/features/frameworks/mbed-trace/*
-mbed-os/features/frameworks/nanostack-libservice/*
 mbed-cloud-client/update-client-hub/source/*
 mbed-cloud-client/update-client-hub/modules/atomic-queue/*
 mbed-cloud-client/update-client-hub/modules/control-center/*

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ If `application-jump-address` is not set, the `application-start-address` will b
 
 ### Firmware Candidate Storage
 
-1. `MBED_CLOUD_CLIENT_UPDATE_STORAGE`, This need to be set in the "macros" section of `mbed_app.json`. Choices are ARM_UCP_FLASHIAP_BLOCKDEVICE and ARM_UCP_FLASHIAP. This determines whether the firmware is stored on a blockdevice or internal flash. If blockdevice is used `ARM_UC_USE_PAL_BLOCKDEVICE=1` must also be set. 
-1. `update-client.storage-address`, The address in sd block device or internal flash where the firmware candidates are stored. **Must align to flash erase boundary**
+1. `MBED_CLOUD_CLIENT_UPDATE_STORAGE`, This need to be set in the "macros" section of `mbed_app.json`. Choices are ARM_UCP_FLASHIAP_BLOCKDEVICE and ARM_UCP_FLASHIAP. This determines whether the firmware is stored on a blockdevice or internal flash. If blockdevice is used `ARM_UC_USE_PAL_BLOCKDEVICE=1` must also be set. If SPI Flash is used for update client storage, please define the macro MBED_CONF_UPDATE_CLIENT_STORAGE_SPIF. If SD card is used for update client storage, please define thhe macro MBED_CONF_UPDATE_CLIENT_STORAGE_SD. If both of the macros are not defined, the bootloader will choose SD card by default.
+1. `update-client.storage-address`, The address in SD block device, SPI flash or internal flash where the firmware candidates are stored. Please note that if the storage is SPI flash, the storage address indexing starts from 0x0. For example, if you would like to let Update Client access the SPI flash starting from its 2MB position, please specify "(1024*1024*2)". **Must align to flash erase boundary**
 1. `update-client.storage-size`, total size on the block device or internal flash reserved for firmware storage. It will be rounded up to align with flash erase sector size automatically.
 1. `update-client.storage-locations`, The number of slots in the firmware storage.
 1. `update-client.storage-page`, The write page size of the underlying storage.

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -14,7 +14,8 @@
         "ARM_UC_PROFILE_MBED_CLOUD_CLIENT=1",
         "ARM_UC_FEATURE_CRYPTO_PAL=0",
         "ARM_UC_FEATURE_CRYPTO_MBEDTLS=1",
-        "Mutex=PlatformMutex"
+        "Mutex=PlatformMutex",
+        "ARM_UC_ALL_TRACE_ENABLE=0"
     ],
     "config": {
         "application-start-address": {
@@ -40,12 +41,12 @@
     },
     "target_overrides": {
         "*": {
-            "target.features_remove": ["LWIP", "STORAGE"],
-            "platform.stdio-baud-rate"    : 115200,
-            "platform.stdio-flush-at-exit": false,
-            "update-client.storage-address"  : "(1024*1024*64)",
-            "update-client.storage-size"     : "(1024*1024*2)",
-            "update-client.storage-locations": 1,
+            "target.features_remove"           : ["LWIP", "STORAGE"],
+            "platform.stdio-baud-rate"         : 115200,
+            "platform.stdio-flush-at-exit"     : false,
+            "update-client.storage-address"    : "(1024*1024*64)",
+            "update-client.storage-size"       : "(1024*1024*2)",
+            "update-client.storage-locations"  : 1,
             "update-client.firmware-header-version": "2"
         },
         "K64F": {
@@ -156,7 +157,8 @@
             "sd.SPI_CS":   "PA_15"
         },
         "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"],
+            "target.components_add"            : ["SPIF"],
+            "target.device_has_remove"         : ["EMAC"],
             "flash-start-address"              : "0x08000000",
             "flash-size"                       : "(2048*1024)",
             "nvstore.area_1_address"           : "(MBED_CONF_APP_FLASH_START_ADDRESS+32*1024)",
@@ -165,7 +167,13 @@
             "nvstore.area_2_size"              : "(16*1024)",
             "update-client.application-details": "(MBED_CONF_APP_FLASH_START_ADDRESS+64*1024)",
             "application-start-address"        : "(MBED_CONF_APP_FLASH_START_ADDRESS+65*1024)",
-            "max-application-size"             : "DEFAULT_MAX_APPLICATION_SIZE"
+            "max-application-size"             : "DEFAULT_MAX_APPLICATION_SIZE",
+            "update-client.storage-address"    : "(1024*1024*2)",
+            "update-client.storage-size"       : "(1024*1024*4)",
+            "spif-driver.SPI_MOSI": "PE_14",
+            "spif-driver.SPI_MISO": "PE_13",
+            "spif-driver.SPI_CLK":  "PE_12",
+            "spif-driver.SPI_CS":   "PE_11"
         },
         "UBLOX_C030_U201": {
             "flash-start-address"              : "0x08000000",

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -41,13 +41,13 @@
     },
     "target_overrides": {
         "*": {
-            "target.features_remove": ["LWIP","STORAGE"],
-            "platform.stdio-baud-rate"    : 115200,
-            "platform.stdio-flush-at-exit": false,
-            "update-client.storage-address"  : "(1024*1024*64)",
-            "update-client.storage-size"     : "(1024*1024*2)",
-            "update-client.firmware-header-version": "2",
-            "update-client.storage-locations"   : 1
+            "target.features_remove"           : ["LWIP", "STORAGE"],
+            "platform.stdio-baud-rate"         : 115200,
+            "platform.stdio-flush-at-exit"     : false,
+            "update-client.storage-address"    : "(1024*1024*64)",
+            "update-client.storage-size"       : "(1024*1024*2)",
+            "update-client.storage-locations"  : 1,
+            "update-client.firmware-header-version": "2"
         },
         "K64F": {
             "flash-start-address"              : "0x0",

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -41,13 +41,13 @@
     },
     "target_overrides": {
         "*": {
-            "target.features_remove"           : ["LWIP", "STORAGE"],
-            "platform.stdio-baud-rate"         : 115200,
-            "platform.stdio-flush-at-exit"     : false,
-            "update-client.storage-address"    : "(1024*1024*64)",
-            "update-client.storage-size"       : "(1024*1024*2)",
-            "update-client.storage-locations"  : 1,
-            "update-client.firmware-header-version": "2"
+            "target.features_remove": ["LWIP","STORAGE"],
+            "platform.stdio-baud-rate"    : 115200,
+            "platform.stdio-flush-at-exit": false,
+            "update-client.storage-address"  : "(1024*1024*64)",
+            "update-client.storage-size"     : "(1024*1024*2)",
+            "update-client.firmware-header-version": "2",
+            "update-client.storage-locations"   : 1
         },
         "K64F": {
             "flash-start-address"              : "0x0",
@@ -168,8 +168,6 @@
             "update-client.application-details": "(MBED_CONF_APP_FLASH_START_ADDRESS+64*1024)",
             "application-start-address"        : "(MBED_CONF_APP_FLASH_START_ADDRESS+65*1024)",
             "max-application-size"             : "DEFAULT_MAX_APPLICATION_SIZE",
-            "update-client.storage-address"    : "(1024*1024*2)",
-            "update-client.storage-size"       : "(1024*1024*4)",
             "spif-driver.SPI_MOSI": "PE_14",
             "spif-driver.SPI_MISO": "PE_13",
             "spif-driver.SPI_CLK":  "PE_12",

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -63,16 +63,31 @@ extern ARM_UC_PAAL_UPDATE MBED_CLOUD_CLIENT_UPDATE_STORAGE;
 #endif
 
 #if defined(ARM_UC_USE_PAL_BLOCKDEVICE) && (ARM_UC_USE_PAL_BLOCKDEVICE==1)
+
+#if defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SD) || (!defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SPIF) && !defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SD))
 #include "SDBlockDevice.h"
+#elif defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SPIF)
+#include "SPIFBlockDevice.h"
+#endif
 
 /* initialise sd card blockdevice */
-#if defined(MBED_CONF_APP_SPI_MOSI) && defined(MBED_CONF_APP_SPI_MISO) && \
-    defined(MBED_CONF_APP_SPI_CLK)  && defined(MBED_CONF_APP_SPI_CS)
-SDBlockDevice sd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO,
-                 MBED_CONF_APP_SPI_CLK,  MBED_CONF_APP_SPI_CS);
-#else
-SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO,
-                 MBED_CONF_SD_SPI_CLK,  MBED_CONF_SD_SPI_CS);
+#if defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SD) || (!defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SPIF) && !defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SD))
+
+  #if defined(MBED_CONF_APP_SPI_MOSI) && defined(MBED_CONF_APP_SPI_MISO) && \
+      defined(MBED_CONF_APP_SPI_CLK)  && defined(MBED_CONF_APP_SPI_CS)
+  SPIFBlockDevice sd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO,
+                   MBED_CONF_APP_SPI_CLK,  MBED_CONF_APP_SPI_CS);
+  
+  #else
+  SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO,
+                   MBED_CONF_SD_SPI_CLK,  MBED_CONF_SD_SPI_CS);
+  #endif
+
+#elif defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SPIF)
+
+  SPIFBlockDevice sd(MBED_CONF_SPIF_DRIVER_SPI_MOSI, MBED_CONF_SPIF_DRIVER_SPI_MISO,
+                   MBED_CONF_SPIF_DRIVER_SPI_CLK,  MBED_CONF_SPIF_DRIVER_SPI_CS);  
+
 #endif
 
 BlockDevice *arm_uc_blockdevice = &sd;


### PR DESCRIPTION
Added macros in main.cpp to toggle SD or SPIF flash mode: MBED_CONF_UPDATE_CLIENT_STORAGE_SD and MBED_CONF_UPDATE_CLIENT_STORAGE_SPIF.
If both macros are not defined, SD is by default used.

For SPIF version of Ublox EVK Odin W2 (mbedConnectCloud board), these values need to be defined in mbed_app.json in addition:
            "update-client.storage-address"    : "(1024 * 1024 * 2)",
            "update-client.storage-size"       : "(1024 * 1024 * 4)",