### PR TITLE
Add GR-PEACH and GR-LYCHEE

### DIFF
--- a/configs/internal_flash_no_rot.json
+++ b/configs/internal_flash_no_rot.json
@@ -90,6 +90,16 @@
         "DISCO_L475VG_IOT01A": {
             "kvstore-size": "2*8*1024",
             "update-client.storage-page": 1
+        },
+        "RZ_A1H": {
+            "target.restrict_size": "0x10000",
+            "kvstore-size": "2*24*1024",
+            "update-client.storage-page": 1
+        },
+        "GR_LYCHEE": {
+            "target.restrict_size": "0x10000",
+            "kvstore-size": "2*24*1024",
+            "update-client.storage-page": 1
         }
     }
 }

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -162,12 +162,17 @@ int main(void)
         firmware_update_test_end();
 #endif
         uint32_t app_start_addr = MBED_CONF_MBED_BOOTLOADER_APPLICATION_START_ADDRESS;
+#if defined(__CORTEX_A9)
+
+        tr_info("Application's start address: 0x%" PRIX32, app_start_addr);
+#else
         uint32_t app_stack_ptr = *((uint32_t *)(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS + 0));
         uint32_t app_jump_addr = *((uint32_t *)(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS + 4));
 
         tr_info("Application's start address: 0x%" PRIX32, app_start_addr);
         tr_info("Application's jump address: 0x%" PRIX32, app_jump_addr);
         tr_info("Application's stack address: 0x%" PRIX32, app_stack_ptr);
+#endif
         tr_info("Forwarding to application...\r\n");
 
         mbed_start_application(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS);


### PR DESCRIPTION
The ``mbed-os.lib`` was updated because the ``mbed-os\tools\arm_pack_manager\index.json`` needs to be updated.

Since Cortex-A does not have the following information, it has been removed from ``main.cpp``.
```.cpp
        uint32_t app_stack_ptr = *((uint32_t *)(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS + 0));
        uint32_t app_jump_addr = *((uint32_t *)(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS + 4));

        tr_info("Application's jump address: 0x%" PRIX32, app_jump_addr);
        tr_info("Application's stack address: 0x%" PRIX32, app_stack_ptr);
```

