### PR TITLE
Drop support for formatted strings.

### DIFF
--- a/modules/minimal-printf.lib
+++ b/modules/minimal-printf.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/minimal-printf/#5cbf9d1dcb5812a8a804a55162b3118523a4eb77

--- a/source/bootloader_common.c
+++ b/source/bootloader_common.c
@@ -29,6 +29,63 @@ const char hexTable[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
                            '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
                           };
 
+
+#if DEVICE_SERIAL
+
+#include "hal/serial_api.h"
+
+static serial_t stdio_uart = { 0 };
+
+/* module variable for keeping track of initialization */
+static bool not_initialized = true;
+
+/**
+ * @brief Initialization serial port if needed.
+ *.
+ */
+static void init_serial()
+{
+    if (not_initialized)
+    {
+        not_initialized = false;
+
+        serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+        serial_baud(&stdio_uart, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
+#endif
+    }
+
+}
+
+/**
+ * @brief Function that directly outputs to serial port in blocking mode.
+ *
+ * @param string outputed to serial port.
+ */
+void boot_debug(const char *s)
+{
+    init_serial();
+
+    while(*s) {
+        serial_putc(&stdio_uart, *s);
+        s++;
+    }
+}
+
+#else
+
+/**
+ * @brief Fake function for boot debug.
+ *
+ * @param unused.
+ */
+void boot_debug(const char *s)
+{
+    (void)s;
+}
+
+#endif // if DEVICE_SERIAL
+
 /**
  * @brief Event handler for UCP callbacks.
  *
@@ -36,8 +93,6 @@ const char hexTable[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
  */
 void arm_ucp_event_handler(uint32_t event)
 {
-    tr_debug("event: %" PRIx32, event);
-
     event_callback = event;
 }
 
@@ -56,8 +111,6 @@ void print_sha256_function(const uint8_t SHA[SIZEOF_SHA256])
         buffer[2 * index]     = hexTable[value >> 4];
         buffer[2 * index + 1] = hexTable[value & 0x0F];
     }
-
-    tr_info("SHA256: %s", buffer);
 }
 
 void print_progress_function(uint32_t progress, uint32_t total)
@@ -69,22 +122,22 @@ void print_progress_function(uint32_t progress, uint32_t total)
 
     if (last_percent != percent) {
         last_percent = percent;
-        tr_trace("\r[BOOT] [");
+        boot_debug("\r[BOOT] [");
 
         /* print + for progress or a space otherwise */
         for (uint8_t index = 0; index < 70; index++) {
             if (index <= percent) {
-                tr_trace("+");
+                boot_debug("+");
             } else {
-                tr_trace(" ");
+                boot_debug(" ");
             }
         }
 
         /* finish progress bar with a newline once complete */
         if (progress >= total) {
-            tr_trace("]\r\n");
+            boot_debug("]\r\n");
         } else {
-            tr_trace("]");
+            boot_debug("]");
 
             /* explicitly flush debug channel, usually this is triggered by \n */
             tr_flush();

--- a/source/bootloader_common.h
+++ b/source/bootloader_common.h
@@ -51,9 +51,11 @@ void print_sha256_function(const uint8_t SHA[SIZEOF_SHA256]);
 
 void print_progress_function(uint32_t progress, uint32_t total);
 
+void boot_debug(const char *s);
+
 #define MBED_BOOTLOADER_ASSERT(condition, ...) { \
     if (!(condition)) {                          \
-        tr_error(__VA_ARGS__);                   \
+        boot_debug("[ERR ] ASSERT\r\n");                   \
         /* coverity[no_escape] */                \
         while (1) __WFI();                       \
     }                                            \
@@ -80,7 +82,7 @@ void print_progress_function(uint32_t progress, uint32_t total);
 #undef tr_debug
 #endif
 #if 0
-#define tr_debug(fmt, ...)   printf("[DBG ] " fmt "\r\n", ##__VA_ARGS__)
+#define tr_debug(fmt, ...)   boot_debug("[DBG ] " fmt "\r\n")
 #else
 #define tr_debug(...)
 #endif
@@ -88,32 +90,28 @@ void print_progress_function(uint32_t progress, uint32_t total);
 #ifdef tr_info
 #undef tr_info
 #endif
-#define tr_info(fmt, ...)    printf("[BOOT] " fmt "\r\n", ##__VA_ARGS__)
+#define tr_info(fmt, ...)    boot_debug("[INF ] " fmt "\r\n")
 
 #ifdef tr_warning
 #undef tr_warning
 #endif
-#define tr_warning(fmt, ...) printf("[WARN] " fmt "\r\n", ##__VA_ARGS__)
+#define tr_warning(fmt, ...) boot_debug("[WRN ] " fmt "\r\n")
 
 #ifdef tr_error
 #undef tr_error
 #endif
-#define tr_error(fmt, ...)   printf("[ERR ] " fmt "\r\n", ##__VA_ARGS__)
+#define tr_error(fmt, ...)   boot_debug("[ERR ] " fmt "\r\n")
 
 #ifdef tr_trace
 #undef tr_trace
 #endif
-#define tr_trace(fmt, ...)   printf(fmt, ##__VA_ARGS__)
+#define tr_trace(fmt, ...)   boot_debug("[TRC ] " fmt "\r\n")
 
 #ifdef tr_flush
 #undef tr_flush
 #endif
-// Disable flushing if mbed-printf is used, since mbed-printf is not buffered
-#ifdef MBED_CONF_MINIMAL_PRINTF_ENABLE_FLOATING_POINT
+
 #define tr_flush(x)
-#else
-#define tr_flush(x)          fflush(stdout)
-#endif
 
 #endif
 #else

--- a/source/firmware_update_test/firmware_update_test.cpp
+++ b/source/firmware_update_test/firmware_update_test.cpp
@@ -31,19 +31,16 @@
 
 void copyAppToSDCard(uint32_t firmware_size)
 {
-    tr_info("Copy active firmware to slot 0\r\n");
+    boot_debug("[DBG ] Copy active firmware to slot 0\r\n");
 
     arm_uc_firmware_details_t details = { 0 };
 
-    tr_info("calculate firmware SHA256\r\n");
     const uint8_t *appStart =
         (const uint8_t *)(MBED_CONF_MBED_BOOTLOADER_APPLICATION_START_ADDRESS);
     mbedtls_sha256(appStart, firmware_size, details.hash, 0);
 
     details.version = UINT32_MAX - 1;
     details.size = firmware_size;
-
-    tr_info("ARM_UCP_Prepare\r\n");
 
     /* clear most recent event */
     event_callback = CLEAR_EVENT;
@@ -63,12 +60,10 @@ void copyAppToSDCard(uint32_t firmware_size)
             __WFI();
         }
     } else {
-        tr_error("ARM_UCP_Prepare failed\r\n");
+        boot_debug("[DBG ] ARM_UCP_Prepare failed\r\n");
     }
 
     /*************************************************************************/
-
-    tr_info("ARM_UCP_Write\r\n");
 
     arm_uc_buffer_t write_buffer = {
         .size_max = firmware_size,
@@ -88,12 +83,10 @@ void copyAppToSDCard(uint32_t firmware_size)
             __WFI();
         }
     } else {
-        tr_error("ARM_UCP_Write failed\r\n");
+        boot_debug("[DBG ] ARM_UCP_Write failed\r\n");
     }
 
     /*************************************************************************/
-
-    tr_info("ARM_UCP_Finalize\r\n");
 
     /* clear most recent event */
     event_callback = CLEAR_EVENT;
@@ -107,7 +100,7 @@ void copyAppToSDCard(uint32_t firmware_size)
             __WFI();
         }
     } else {
-        tr_error("ARM_UCP_Finalize failed\r\n");
+        boot_debug("[DBG ] ARM_UCP_Finalize failed\r\n");
     }
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -84,12 +84,6 @@ int main(void)
     /* Initialize PAL */
     arm_uc_error_t ucp_result = ARM_UCP_Initialize(arm_ucp_event_handler);
 
-    /* If a reboot message was left from last boot, print it here */
-    if (existsErrorMessageLeadingToReboot()) {
-        tr_info("error message leading to reboot: %s",
-                errorMessageLeadingToReboot());
-    }
-
 #if defined(BOOTLOADER_POWER_CUT_TEST) && (BOOTLOADER_POWER_CUT_TEST == 1)
     power_cut_test_setup();
     const uint32_t firmware_size = 1024;
@@ -105,31 +99,7 @@ int main(void)
     /* Print bootloader information                                          */
     /*************************************************************************/
 
-    tr_info("Mbed Bootloader");
-
-    /* although not referenced, arm_size is used indirectly in sizeof() below */
-    /* coverity[set_but_not_used] */
-    uint8_t arm_size[] = BOOTLOADER_ARM_SOURCE_HASH;
-
-    tr_trace("[BOOT] ARM: ");
-    for (uint32_t index = 0; index < sizeof(arm_size); index++) {
-        tr_trace("%02" PRIX8, bootloader.arm_hash[index]);
-    }
-    tr_trace("\r\n");
-
-    /* although not referenced, oem_size is used indirectly in sizeof() below */
-    /* coverity[set_but_not_used] */
-    uint8_t oem_size[] = BOOTLOADER_OEM_SOURCE_HASH;
-
-    tr_trace("[BOOT] OEM: ");
-    for (uint32_t index = 0; index < sizeof(oem_size); index++) {
-        tr_trace("%02" PRIX8, bootloader.oem_hash[index]);
-    }
-    tr_trace("\r\n");
-
-    tr_info("Layout: %" PRIu32 " %" PRIX32,
-            bootloader.layout,
-            (uint32_t) &bootloader);
+    boot_debug("[DBG ] Mbed Bootloader\r\n");
 
     /*************************************************************************/
     /* Update                                                                */
@@ -161,14 +131,6 @@ int main(void)
 #elif defined(FIRMWARE_UPDATE_TEST) && (FIRMWARE_UPDATE_TEST == 1)
         firmware_update_test_end();
 #endif
-        uint32_t app_start_addr = MBED_CONF_MBED_BOOTLOADER_APPLICATION_START_ADDRESS;
-        uint32_t app_stack_ptr = *((uint32_t *)(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS + 0));
-        uint32_t app_jump_addr = *((uint32_t *)(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS + 4));
-
-        tr_info("Application's start address: 0x%" PRIX32, app_start_addr);
-        tr_info("Application's jump address: 0x%" PRIX32, app_jump_addr);
-        tr_info("Application's stack address: 0x%" PRIX32, app_stack_ptr);
-        tr_info("Forwarding to application...\r\n");
 
         mbed_start_application(MBED_CONF_APP_APPLICATION_JUMP_ADDRESS);
     }


### PR DESCRIPTION
Against to usage "printf" family function use serial_hal functions. Output only simple messages of bootloader stages.