### PR TITLE
Support Nuvoton targets

### DIFF
--- a/drivers/storage/COMPONENT_NUSD.lib
+++ b/drivers/storage/COMPONENT_NUSD.lib
@@ -1,0 +1,1 @@
+https://github.com/OpenNuvoton/NuMaker-mbed-SD-driver/#f9f81fcba836a651e57fa3b3ed31ba5954142306

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -15,6 +15,7 @@
                  "spif",
                  "qspif",
                  "sd",
+                 "nusd",
                  "flashiap-block-device",
                  "direct-access-devicekey",
                  "tdbstore",
@@ -77,8 +78,6 @@
             "update-client.storage-locations"          : 1,
             "update-client.firmware-header-version"    : "2",
             "target.restrict_size"                     : "0x8000",
-            "target.components_add"                    : ["SD"],
-            "sd.CRC_ENABLED"                           : 0,
             "storage.storage_type"                     : "FILESYSTEM",
             "storage_filesystem.internal_base_address" : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE)",
             "update-client.application-details"        : "(MBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS + MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE)",
@@ -86,14 +85,20 @@
             "target.extra_labels_remove"               : [ "WICED", "CORDIO", "PSA", "MBED_SPM" ]
         },
         "K64F": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*4*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "K66F": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*4*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "KW24D": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*2*1024)",
             "sd.SPI_CS"                                : "PTC4",
             "sd.SPI_MOSI"                              : "PTC6",
@@ -102,16 +107,22 @@
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "NUCLEO_L476RG": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*2*1024)",
             "mbed-bootloader.application-start-address": "(MBED_ROM_START+38*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "DISCO_L476VG": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*2*1024)",
             "mbed-bootloader.application-start-address": "(MBED_ROM_START+38*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "NUCLEO_F411RE": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
             "sd.SPI_CS"                                : "PB_9",
             "sd.SPI_MOSI"                              : "PC_3",
@@ -120,10 +131,14 @@
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "NUCLEO_F429ZI": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "NUCLEO_F207ZG": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
             "sd.SPI_MOSI"                              : "PC_12",
             "sd.SPI_MISO"                              : "PC_11",
@@ -132,19 +147,27 @@
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "NUCLEO_L073RZ": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "mbed-bootloader.bootloader-size"          : "(34*1024)",
             "target.restrict_size"                     : "0x8800",
             "target.boot-stack-size"                   : "1024"
         },
         "UBLOX_EVK_ODIN_W2": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "UBLOX_C030_U201": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "NRF52840_DK": {
+            "target.components_add"                    : ["SD"],
+            "sd.CRC_ENABLED"                           : 0,
             "storage_filesystem.internal_base_address" : "(1016*1024)",
             "storage_filesystem.rbp_internal_size"     : "(2*4*1024)",
             "update-client.application-details"        : "(236*1024)",
@@ -161,6 +184,81 @@
             "target.features_remove"                   : ["CRYPTOCELL310"],
             "target.macros_remove"                     : ["MBEDTLS_CONFIG_HW_SUPPORT"],
             "target.macros_add"                        : ["NRFX_RNG_ENABLED=1", "RNG_ENABLED=1", "NRF_QUEUE_ENABLED=1"]
+        },
+        "NUMAKER_PFM_NUC472": {
+            "mbed-bootloader.bootloader-size"           : "(64*1024)",
+            "target.restrict_size"                      : "0x10000",
+            "storage.storage_type"                      : "FILESYSTEM",
+            "storage_filesystem.filesystem"             : "LITTLE",
+            "storage_filesystem.blockdevice"            : "other",
+            "storage_filesystem.internal_base_address"  : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE)",
+            "storage_filesystem.rbp_internal_size"      : "(2*4*1024)",
+            "storage_filesystem.external_base_address"  : "(0x0)",
+            "storage_filesystem.external_size"          : "(1024*1024*64)",
+            "target.device_has_remove"                  : ["LPTICKER"],
+            "target.components_add"                     : ["NUSD"],
+            "nusd.provide-default-blockdevice"          : true,
+            "nusd.provide-kvstore-other-blockdevice"    : true
+        },
+        "NUMAKER_PFM_M487": {
+            "mbed-bootloader.bootloader-size"           : "(64*1024)",
+            "target.restrict_size"                      : "0x10000",
+            "storage.storage_type"                      : "FILESYSTEM",
+            "storage_filesystem.filesystem"             : "LITTLE",
+            "storage_filesystem.blockdevice"            : "other",
+            "storage_filesystem.internal_base_address"  : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE)",
+            "storage_filesystem.rbp_internal_size"      : "(2*4*1024)",
+            "storage_filesystem.external_base_address"  : "(0x0)",
+            "storage_filesystem.external_size"          : "(1024*1024*64)",
+            "target.device_has_remove"                  : ["LPTICKER"],
+            "target.components_add"                     : ["NUSD"],
+            "nusd.provide-default-blockdevice"          : true,
+            "nusd.provide-kvstore-other-blockdevice"    : true
+        },
+        "NUMAKER_IOT_M487": {
+            "mbed-bootloader.bootloader-size"           : "(64*1024)",
+            "target.restrict_size"                      : "0x10000",
+            "storage.storage_type"                      : "FILESYSTEM",
+            "storage_filesystem.filesystem"             : "LITTLE",
+            "storage_filesystem.blockdevice"            : "other",
+            "storage_filesystem.internal_base_address"  : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE)",
+            "storage_filesystem.rbp_internal_size"      : "(2*4*1024)",
+            "storage_filesystem.external_base_address"  : "(0x0)",
+            "storage_filesystem.external_size"          : "(1024*1024*64)",
+            "target.device_has_remove"                  : ["LPTICKER"],
+            "target.components_add"                     : ["NUSD"],
+            "nusd.provide-default-blockdevice"          : true,
+            "nusd.provide-kvstore-other-blockdevice"    : true
+        },
+        "NU_PFM_M2351_NPSA_NS": {
+            "mbed-bootloader.bootloader-size"           : "(64*1024)",
+            "target.restrict_size"                      : "0x10000",
+            "storage.storage_type"                      : "FILESYSTEM",
+            "storage_filesystem.filesystem"             : "LITTLE",
+            "storage_filesystem.blockdevice"            : "other",
+            "storage_filesystem.internal_base_address"  : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE)",
+            "storage_filesystem.rbp_internal_size"      : "(2*4*1024)",
+            "storage_filesystem.external_base_address"  : "(0x0)",
+            "storage_filesystem.external_size"          : "(1024*1024*64)",
+            "target.device_has_remove"                  : ["LPTICKER"],
+            "target.components_add"                     : ["NUSD"],
+            "nusd.provide-default-blockdevice"          : true,
+            "nusd.provide-kvstore-other-blockdevice"    : true
+        },
+        "NUMAKER_IOT_M263A": {
+            "mbed-bootloader.bootloader-size"           : "(64*1024)",
+            "target.restrict_size"                      : "0x10000",
+            "storage.storage_type"                      : "FILESYSTEM",
+            "storage_filesystem.filesystem"             : "LITTLE",
+            "storage_filesystem.blockdevice"            : "other",
+            "storage_filesystem.internal_base_address"  : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE)",
+            "storage_filesystem.rbp_internal_size"      : "(2*4*1024)",
+            "storage_filesystem.external_base_address"  : "(0x0)",
+            "storage_filesystem.external_size"          : "(1024*1024*64)",
+            "target.device_has_remove"                  : ["LPTICKER"],
+            "target.components_add"                     : ["NUSD"],
+            "nusd.provide-default-blockdevice"          : true,
+            "nusd.provide-kvstore-other-blockdevice"    : true
         }
     }
 }


### PR DESCRIPTION
This PR tries to add Nuvoton support for pelion application on the following targets:

- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M487
- NUMAKER_IOT_M487
- NU_PFM_M2351_NPSA_NS
- NUMAKER_IOT_M263A

Compare to other targets, Nuvoton support has the following differences:

1. Use `NUSD` rather than `SD` for external storage. `NUSD` is SD card in SD bus mode and is on-board on Nuvoton targets. Because Mbed OS doesn't support SDIO HAL yet, provide its dedicated driver `COMPONENT_NUSD.lib` instead.
1. Configure (max) bootloader size to 64KiB from 32KiB. This leaves room for debug build.
1. **NU_PFM_M2351_NPSA_NS** is non-PSA non-secuare TZ target. The memory configuration of its pre-built secure image/lib in mbed-os cannot afford pelion application. Provide specialized version in the application instead.

**Note:** **NU_PFM_M2351_NPSA_NS** and **NUMAKER_IOT_M263A** require mbed-os to be 5.14.0 or afterwards.
