### PR TITLE
DISCO_F746NG - internal flash support

### DIFF
--- a/configs/internal_flash_no_rot.json
+++ b/configs/internal_flash_no_rot.json
@@ -106,6 +106,17 @@
         },
         "NUCLEO_F429ZI": {
             "kvstore-size": "2*64*1024"
+        },
+        "DISCO_F746NG": {
+            "mbed-bootloader.bootloader-size"          : "(32*1024)",
+            "kvstore-size"                             : "(2*32*1024)",
+            "update-client.application-details"        : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE + KVSTORE_SIZE)",
+            "update-client.storage-address"            : "(MBED_ROM_START+512*1024)",
+            "update-client.storage-size"               : "(512*1024)",
+            "update-client.storage-locations"          : 1,
+            "update-client.storage-page"               : 1,
+            "mbed-bootloader.max-application-size"     : "((32+127+256)*1024)",
+            "target.device_has_remove"                 : [ "LPTICKER" ]
         }
     }
 }


### PR DESCRIPTION
Support for DISCO_F746NG with the following assumptions:
- we use internal flash only
- meant for a very small application

Thus, we derive the following memory layout:

```
Start        Size    Item
0x0800 0000  32 kB   Bootloader
0x0800 8000  64 kB   KVStore (2x32 kB flash erase sectors)
0x0801 8000  1 kB    Application header
0x0801 8400  415 kB  Application (31 + 128 + 256)
0x0808 0000  512 kB  Firmware download area (512 kB)
```

The layout is unconventional (typically you would want to the KVStore
at the start or end of flash in bank2), but as this board only has one bank
and the flash erase sectors are small in the beginning and then grow double
in size in each step - you're sort of forced to do it this way.

However, due to the way how .BIN-files are flashed and as the empty KVStore
is padded between bootloader and application -> every time you flash the
.bin -file - you will lose the KVStore contents (and thus the device identity
if you are using it with Pelion Device Management client).

To retain device identity, flash the .bin file for the 1st time and after
that - either

1. update the device using the Pelion Device Management firmware
   update mechanism OR
1. compile a .hex file and flash that using pyocd flash (.hex files have
   the flashing addresses and it will then only erase the correct sectors).

A different configuration could be done, where external flash would be
used for firmware download area - that would free up the app size to be
much larger (415+512 kB).

Compile with;

`mbed compile -t GCC_ARM -m DISCO_F746NG --profile=tiny.json --app-config=configs/internal_flash_no_rot.json`