### PR TITLE
Depend on fat_chan to fix Baremetal builds

### DIFF
--- a/configs/block_device_fake_rot.json
+++ b/configs/block_device_fake_rot.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/configs/external_kvstore_with_qspif.json
+++ b/configs/external_kvstore_with_qspif.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/configs/internal_flash_no_rot.json
+++ b/configs/internal_flash_no_rot.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/configs/internal_kvstore_with_qspif.json
+++ b/configs/internal_kvstore_with_qspif.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/configs/internal_kvstore_with_sd.json
+++ b/configs/internal_kvstore_with_sd.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/configs/internal_kvstore_with_spif.json
+++ b/configs/internal_kvstore_with_spif.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "spif-driver",
                  "qspif",

--- a/configs/kvstore_and_fw_candidate_on_sd.json
+++ b/configs/kvstore_and_fw_candidate_on_sd.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/configs/psa.json
+++ b/configs/psa.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/configs/test_configs/greentea.json
+++ b/configs/test_configs/greentea.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -12,6 +12,7 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
+                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",


### PR DESCRIPTION
After a change in Mbed OS, all Chan FatFS values are now in mbed_lib.json.
This forces us to depend on "fat-chan" if we want to include "kv_config.cpp"
which in turn include "FatFileSystem.h"