### PR TITLE
Add NUCLEO_L4R5ZI to Jenkins & make_release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,6 +117,7 @@ def build_test_config = [
   ["K64F", "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["K64F", "configs/internal_kvstore_with_sd.json",       "GCC_ARM"],
   ["K66F", "configs/internal_flash_no_rot.json",          "GCC_ARM"],
+  ["NUCLEO_L4R5ZI",       "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["NUCLEO_F429ZI",       "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["UBLOX_EVK_ODIN_W2",   "configs/internal_kvstore_with_sd.json",       "GCC_ARM"],
   ["NUCLEO_F411RE",       "configs/kvstore_and_fw_candidate_on_sd.json", "GCC_ARM"],

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -52,6 +52,7 @@ targets = [
     ("K64F", "internal_flash_no_rot"),  # cloud client
     ("K64F", "internal_kvstore_with_sd"),  # cloud client
     ("K66F", "internal_flash_no_rot"),  # cloud client
+    ("NUCLEO_L4R5ZI", "internal_flash_no_rot"),  # cloud client
     ("NUCLEO_F429ZI", "internal_flash_no_rot"),  # cloud client
     ("UBLOX_EVK_ODIN_W2", "internal_kvstore_with_sd"),  # cloud client
     ("NUCLEO_F411RE", "kvstore_and_fw_candidate_on_sd"),  # cloud client


### PR DESCRIPTION
It works just fine out of box with the internal_flash_no_rot -config,
so it's enough to add it to the Jenkins & releasing.

For this board it yields the following memory map:

```
_32 kB - BOOTLOADER
__1 kB – APPLICATION HEADER
991 kB - APPLICATION
_32 kB - KVStore (2x16 kB)
991 kB - FW download area
```
