### PR TITLE
Enables GCC's Link-Time Optimization

### DIFF
--- a/tiny.json
+++ b/tiny.json
@@ -1,18 +1,19 @@
 {
     "GCC_ARM": {
-        "common": ["-c", "-Wall", "-Wextra",
+        "common": ["-Wall", "-Wextra",
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g"],
-        "asm": ["-x", "assembler-with-cpp"],
-        "c": ["-std=gnu11"],
-        "cxx": ["-std=gnu++14", "-fno-rtti", "-Wvla"],
-        "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
-               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
-               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-specs=nano.specs"]
+                   "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g",
+                   "-flto"],
+        "asm": ["-c", "-x", "assembler-with-cpp"],
+        "c":   ["-c", "-std=gnu11"],
+        "cxx": ["-c", "-std=gnu++14", "-fno-rtti", "-Wvla"],
+        "ld":  ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
+                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
+                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
+                "-specs=nano.specs", "-u main"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
Idea taken from ARMmbed/mbed-os#11856 . We also depend on that PR because common flags which were earlier only given to compiler needs to given also now for the linker. That PR takes care of adding the flags to linking phase.