### PR TITLE
Adds NRF52840_DK as release target and cleans up make_release.py

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,6 +123,7 @@ def build_test_config = [
   ["K64F", "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["K64F", "configs/internal_kvstore_with_sd.json",       "GCC_ARM"],
   ["K66F", "configs/internal_flash_no_rot.json",          "GCC_ARM"],
+  ["NRF52840_DK",         "configs/internal_kvstore_with_qspif.json",    "GCC_ARM"],
   ["NUCLEO_L4R5ZI",       "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["NUCLEO_F429ZI",       "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["UBLOX_EVK_ODIN_W2",   "configs/internal_kvstore_with_sd.json",       "GCC_ARM"],

--- a/configs/internal_kvstore_with_qspif.json
+++ b/configs/internal_kvstore_with_qspif.json
@@ -92,14 +92,20 @@
             "storage_tdb_internal.internal_size"        : "APP_KVSTORE_SIZE",
             "update-client.application-details"         : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE+MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE)",
             "mbed-bootloader.application-start-address" : "(MBED_CONF_UPDATE_CLIENT_APPLICATION_DETAILS + MBED_BOOTLOADER_ACTIVE_HEADER_REGION_SIZE)",
-            "target.components_add"                     : ["QSPIF"],
             "update-client.storage-address"             : "0",
             "update-client.storage-size"                : "((MBED_ROM_START + MBED_ROM_SIZE - MBED_CONF_MBED_BOOTLOADER_APPLICATION_START_ADDRESS) * MBED_CONF_UPDATE_CLIENT_STORAGE_LOCATIONS)",
-            "update-client.storage-locations"           : 1
+            "update-client.storage-locations"           : 1,
+            "update-client.storage-page"                : 1
         },
         "DISCO_L475VG_IOT01A": {
             "target.restrict_size"           : "0x9000",
             "mbed-bootloader.bootloader-size": "(36*1024)"
+        },
+        "NRF52840_DK": {
+            "target.static_memory_defines"             : true,
+            "target.features_remove"                   : ["CRYPTOCELL310"],
+            "target.macros_remove"                     : ["MBEDTLS_CONFIG_HW_SUPPORT"],
+            "target.macros_add"                        : ["NRFX_RNG_ENABLED=1", "RNG_ENABLED=1", "NRF_QUEUE_ENABLED=1"]
         }
     }
 }

--- a/configs/uicr.md
+++ b/configs/uicr.md
@@ -1,0 +1,3 @@
+# Nordic Semiconductor Bootloader support
+
+If SoftDevice is used the start address of the bootloader needs to be passed for the device by using User Information Configuration Registers (UICR). This can be accomplished by combining the produced bootloader binary with an uicr.hex file. If SoftDevice is not used this setting doesn't have any effect. For futher instructions please see the [documentation](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fsds_s132%2FSDS%2Fs1xx%2Fmbr_bootloader%2Fbootloader.html&cp=3_4_2_0_11_1).

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -52,6 +52,7 @@ targets = [
     ("NUCLEO_L4R5ZI", "internal_flash_no_rot"),  # cloud client
     ("NUCLEO_F429ZI", "internal_flash_no_rot"),  # cloud client
     ("UBLOX_EVK_ODIN_W2", "internal_kvstore_with_sd"),  # cloud client
+    ("NRF52840_DK", "internal_kvstore_with_qspif"),
     ("NUCLEO_F411RE", "kvstore_and_fw_candidate_on_sd"),  # cloud client
     ("DISCO_L475VG_IOT01A", "internal_kvstore_with_qspif"),  # cloud client
     ("LPC55S69_NS", "psa"),  # cloud client

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -30,12 +30,6 @@ bootloader_configs = {
     "internal_flash_no_rot": (
         "configs/internal_flash_no_rot.json", "internal-flash", "no-rot"
     ),
-    "nrf52_block_device_fake_rot": (
-        "configs/nrf52_block_device_fake_rot.json", "block-device", "fake-rot"
-    ),
-    "nrf52_internal_flash_fake_rot": (
-        "configs/nrf52_internal_flash_fake_rot.json", "internal-flash", "fake-rot"
-    ),
     "internal_kvstore_with_sd": (
         "configs/internal_kvstore_with_sd.json", "internal-flash", "sd-update"
     ),
@@ -228,7 +222,7 @@ if __name__ == '__main__':
             map_file = path.join(build_dir, bootloader_repo_name + '_application.map')
 
             bin_file_type = "bin"
-            if target == "NRF52_DK" or target == "LPC55S69_NS":
+            if target == "NRF52840_DK" or target == "LPC55S69_NS":
                 bin_file_type = "hex"
             bin_file = path.join(build_dir, bootloader_repo_name + '.' + bin_file_type)
 
@@ -249,10 +243,10 @@ if __name__ == '__main__':
                 release_desc, bin_file_type)
             dst = path.join(result_dir, fn)
 
-            if target == "NRF52_DK":
+            if target == "NRF52840_DK":
                 print("merging uicr with bootloader")
                 # merge bootloader with uicr
-                uicr_fn = "scripts/uicr-0x74000.hex"
+                uicr_fn = "configs/uicr-0x74000.hex"
                 mergehex(bin_file, uicr_fn)
 
             print(dst, path.isfile(dst))


### PR DESCRIPTION
~ARMmbed/mbed-os#11856 needs to go in to enable Link-Time Optimization first. The code size has increased a bit and some target's don't fit to given size limits anymore.~ Seems to fit without LTO currently.