### PR TITLE
Restore LPTICKER

### DIFF
--- a/configs/internal_flash_no_rot.json
+++ b/configs/internal_flash_no_rot.json
@@ -122,8 +122,7 @@
             "update-client.storage-size"               : "(512*1024)",
             "update-client.storage-locations"          : 1,
             "update-client.storage-page"               : 1,
-            "mbed-bootloader.max-application-size"     : "((32+127+256)*1024)",
-            "target.device_has_remove"                 : [ "LPTICKER" ]
+            "mbed-bootloader.max-application-size"     : "((32+127+256)*1024)"
         },
         "NUCLEO_H743ZI2": {
             "kvstore-size"                     : "(2*128*1024)",

--- a/configs/internal_kvstore_with_sd.json
+++ b/configs/internal_kvstore_with_sd.json
@@ -98,8 +98,7 @@
             "sd.CRC_ENABLED"                            : 0,
             "update-client.storage-address"             : "0",
             "update-client.storage-size"                : "((MBED_ROM_START + MBED_ROM_SIZE - MBED_CONF_MBED_BOOTLOADER_APPLICATION_START_ADDRESS) * MBED_CONF_UPDATE_CLIENT_STORAGE_LOCATIONS)",
-            "update-client.storage-locations"           : 1,
-            "target.device_has_remove"                 : [ "LPTICKER" ]
+            "update-client.storage-locations"           : 1
         },
         "K64F": {
             "target.extra_labels_remove"                : [ "PSA" ]

--- a/configs/kvstore_and_fw_candidate_on_sd.json
+++ b/configs/kvstore_and_fw_candidate_on_sd.json
@@ -61,8 +61,8 @@
                     "(storage-locations is set to 1 in this configuration)",
                     "",
                     "NRF52840_DK: Please note the config is different. The kvstore region is at the end of flash.",
-                    "Setting `target.static_memory_defines` as `true` is an alternative for the workaround",
-                    "https://github.com/ARMmbed/mbed-os/pull/11510 . The PR in question is waiting for approval"
+                    "Setting `target.static_memory_defines` as `true` is required due to an issue",
+                    "https://github.com/ARMmbed/mbed-os/issues/11737"
             ]
         }
     },

--- a/configs/kvstore_and_fw_candidate_on_sd.json
+++ b/configs/kvstore_and_fw_candidate_on_sd.json
@@ -62,9 +62,7 @@
                     "",
                     "NRF52840_DK: Please note the config is different. The kvstore region is at the end of flash.",
                     "Setting `target.static_memory_defines` as `true` is an alternative for the workaround",
-                    "https://github.com/ARMmbed/mbed-os/pull/11510 . The PR in question is waiting for approval",
-                    "",
-                    "Reason for removing labels and some components like PSA or LPTICKER is to fit bootloader into 32kB"
+                    "https://github.com/ARMmbed/mbed-os/pull/11510 . The PR in question is waiting for approval"
             ]
         }
     },
@@ -108,20 +106,17 @@
         },
         "NUCLEO_L476RG": {
             "target.restrict_size"                     : "0x8800",
-            "mbed-bootloader.bootloader-size"          : "(34*1024)",
-            "target.device_has_remove"                 : [ "LPTICKER" ]
+            "mbed-bootloader.bootloader-size"          : "(34*1024)"
         },
         "NUCLEO_F411RE": {
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
             "sd.SPI_CS"                                : "PB_9",
             "sd.SPI_MOSI"                              : "PC_3",
             "sd.SPI_MISO"                              : "PC_2",
-            "sd.SPI_CLK"                               : "PC_7",
-            "target.device_has_remove"                 : [ "LPTICKER" ]
+            "sd.SPI_CLK"                               : "PC_7"
         },
         "NUCLEO_F429ZI": {
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
-            "target.device_has_remove"                 : [ "LPTICKER" ],
             "target.extra_labels_remove"               : [ "PSA"]
         },
         "NUCLEO_F207ZG": {
@@ -137,8 +132,7 @@
             "target.boot-stack-size"                   : "1024"
         },
         "UBLOX_C030_U201": {
-            "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
-            "target.device_has_remove"                 : [ "LPTICKER" ]
+            "storage_filesystem.rbp_internal_size"     : "(2*16*1024)"
         },
         "NRF52840_DK": {
             "storage_filesystem.internal_base_address" : "(1016*1024)",

--- a/configs/psa.json
+++ b/configs/psa.json
@@ -92,32 +92,12 @@
         },
         "LPC55S69_NS": {
             "target.components_remove"                     : [ "SPM_MAILBOX" ],
-            "target.features_remove"                       : [ "BLE" ],
             "target.macros_remove"                         : ["MBED_FAULT_HANDLER_DISABLED"],
             "storage_filesystem.internal_base_address"     : "0x94000",
             "storage_filesystem.rbp_internal_size"         : "(15*1024)",
             "update-client.application-details"            : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE)",
             "mbed-bootloader.default-max-application-size" : "(MBED_ROM_START + MBED_ROM_SIZE - MBED_CONF_MBED_BOOTLOADER_APPLICATION_START_ADDRESS - MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE)",
-            "target.secure_image_filename"                 : null,
-            "platform.stdio-baud-rate"                     : 115200,
-            "target.device_has_remove"                     : [
-                                                              "SERIAL_ASYNCH",
-                                                              "SERIAL_FC",
-                                                              "PORTOUT",
-                                                              "PORTINOUT",
-                                                              "RTC",
-                                                              "I2C_ASYNCH",
-                                                              "I2CSLAVE",
-                                                              "SPI_ASYNCH",
-                                                              "STDIO_MESSAGES",
-                                                              "LPTICKER",
-                                                              "CRC",
-                                                              "PORTIN",
-                                                              "PWMOUT",
-                                                              "ANALOGIN",
-                                                              "ANALOGOUT",
-                                                              "I2C"
-                                                             ]
+            "target.secure_image_filename"                 : null
         }
     }
 }


### PR DESCRIPTION
It was premature optimization to remove LPTICKER and has been causing issues with some boards. Lets put it back.