### PR TITLE
Enables GCC's Link-Time Optimization for 5.15 release branch

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606

--- a/tiny.json
+++ b/tiny.json
@@ -1,18 +1,24 @@
 {
     "GCC_ARM": {
-        "common": ["-c", "-Wall", "-Wextra",
+        "common": ["-Wall", "-Wextra",
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g"],
-        "asm": ["-x", "assembler-with-cpp"],
-        "c": ["-std=gnu11"],
-        "cxx": ["-std=gnu++14", "-fno-rtti", "-Wvla"],
-        "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
+                   "-fomit-frame-pointer", "-Os", "-flto", "-DNDEBUG", "-g"],
+        "asm": ["-c", "-x", "assembler-with-cpp"],
+        "c": ["-c", "-std=gnu11"],
+        "cxx": ["-c", "-std=gnu++14", "-fno-rtti", "-Wvla"],
+        "ld": ["-Wall", "-Wextra",
+               "-Wno-unused-parameter", "-Wno-missing-field-initializers",
+               "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
+               "-ffunction-sections", "-fdata-sections", "-funsigned-char",
+               "-MMD", "-fno-delete-null-pointer-checks",
+               "-fomit-frame-pointer", "-Os", "-flto", "-DNDEBUG", "-g",
+               "-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-specs=nano.specs"]
+               "-specs=nano.specs", "-u main"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
Done with Mbed OS's release- and develop-profile once Mbed OS 6 is out. Here we rely to tiny.json to do the same.