### PR TITLE
NUCLEO_H742ZI2 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,6 +129,7 @@ def build_test_config = [
   ["DISCO_L475VG_IOT01A", "configs/internal_kvstore_with_qspif.json",    "GCC_ARM"],
   ["LPC55S69_NS",         "configs/psa.json",                            "GCC_ARM"],
   ["NUCLEO_F303RE",       "configs/internal_kvstore_with_spif.json",     "GCC_ARM"],
+  ["NUCLEO_H743ZI2",      "configs/internal_flash_no_rot.json",          "GCC_ARM"]
 ]
 
 

--- a/configs/internal_flash_no_rot.json
+++ b/configs/internal_flash_no_rot.json
@@ -12,7 +12,6 @@
                  "filesystem",
                  "filesystemstore",
                  "littlefs",
-                 "fat_chan",
                  "spif",
                  "qspif",
                  "sd",
@@ -107,6 +106,15 @@
         },
         "NUCLEO_F429ZI": {
             "kvstore-size": "2*64*1024"
+        },
+        "NUCLEO_H743ZI2": {
+            "mbed-bootloader.bootloader-size"          : "(2 * 128 * 1024)",
+            "target.restrict_size"                     : "0x20000",
+            "update-client.application-details"        : "(MBED_ROM_START + (2 * 128 * 1024))",
+            "update-client.storage-address"            : "(MBED_ROM_START + (1024 * 1024) + KVSTORE_SIZE)",
+            "mbed-bootloader.max-application-size"     : "(6 * 128 * 1024)",
+            "kvstore-size"                             : "(2 * 128 * 1024)",
+            "target.device_has_remove"                 : [ "LPTICKER" ]
         },
         "DISCO_F746NG": {
             "mbed-bootloader.bootloader-size"          : "(32*1024)",

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -61,7 +61,8 @@ targets = [
     ("NUCLEO_F411RE", "kvstore_and_fw_candidate_on_sd"),  # cloud client
     ("DISCO_L475VG_IOT01A", "internal_kvstore_with_qspif"),  # cloud client
     ("LPC55S69_NS", "psa"),  # cloud client
-    ("NUCLEO_F303RE", "internal_kvstore_with_spif")  # cloud client
+    ("NUCLEO_F303RE", "internal_kvstore_with_spif"),  # cloud client
+    ("NUCLEO_H743ZI2", "internal_flash_no_rot")  # cloud client
 ]
 toolchain = "GCC_ARM"
 profile = "release"  # default value, changed via command line arg --profile


### PR DESCRIPTION
This board has 2 MB of flash, each flash erase sector is 128 kilobytes.
- Bank 1
    - 2 x 128kB for BOOTLOADER
    - 6 x 128kB App header (1 kb) and Application
- Bank 2
    - 2 x 128kB for KVStore
    - 6 x 128kB for FW download area

Added it also to Jenkinsfile and release script.

Removed fat_chan from requirements, as it's really not needed in
internal flash case (we use tdbstore).