### PR TITLE
add support for L496AG

### DIFF
--- a/configs/external_kvstore_with_qspif.json
+++ b/configs/external_kvstore_with_qspif.json
@@ -110,6 +110,10 @@
         "DISCO_L475VG_IOT01A": {
             "target.restrict_size"           : "0x9000",
             "mbed-bootloader.bootloader-size": "(36*1024)"
+        },
+        "DISCO_L496AG": {
+            "target.restrict_size"           : "0x9000",
+            "mbed-bootloader.bootloader-size": "(36*1024)"
         }
     }
 }

--- a/configs/internal_kvstore_with_qspif.json
+++ b/configs/internal_kvstore_with_qspif.json
@@ -102,6 +102,10 @@
             "target.restrict_size"           : "0x9000",
             "mbed-bootloader.bootloader-size": "(36*1024)"
         },
+        "DISCO_L496AG": {
+            "target.restrict_size"           : "0x9000",
+            "mbed-bootloader.bootloader-size": "(36*1024)"
+        },
         "NRF52840_DK": {
             "target.static_memory_defines"             : true,
             "target.features_remove"                   : ["CRYPTOCELL310"],


### PR DESCRIPTION
Add support for DISCO_L496AG.
Bootloader built with external_kvstore_with_qspif.json is verified and merged in mbed-os-example-pelion today, also verified with mbed-cloud-client-example (4.3.0)
Bootloader built with internal_kvstore_with_qspif.json is verified in mbed-cloud-client-example