### PR TITLE
DISCO_F769 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,6 +110,7 @@ def build_test_config = [
   ["NUCLEO_F303RE",       "mbed_app.json", "GCC_ARM"],
   ["NUCLEO_F411RE",       "mbed_app.json", "GCC_ARM"],
   ["NUCLEO_F429ZI",       "mbed_app.json", "GCC_ARM"],
+  ["DISCO_F769NI",        "mbed_app.json", "GCC_ARM"],
 
   // Bootloaders for just testing the build
   ["NRF52840_DK",   "configs/kvstore_and_fw_candidate_on_sd.json", "GCC_ARM"],
@@ -131,6 +132,7 @@ def build_test_config = [
   ["DISCO_L475VG_IOT01A", "configs/internal_kvstore_with_qspif.json",    "GCC_ARM"],
   ["LPC55S69_NS",         "configs/psa.json",                            "GCC_ARM"],
   ["NUCLEO_F303RE",       "configs/internal_kvstore_with_spif.json",     "GCC_ARM"],
+  ["DISCO_F769NI",        "configs/internal_flash_no_rot.json",          "GCC_ARM"],
 ]
 
 
@@ -255,6 +257,7 @@ def smoke_test_config = [
   "NUCLEO_F303RE":  ["toolchains": [ "GCC_ARM"], "raas": "https://auli.mbedcloudtesting.com:443"],
   "NUCLEO_F411RE":  ["toolchains": [ "GCC_ARM"], "raas": "https://ruka.mbedcloudtesting.com:443"],
   "NUCLEO_F429ZI":  ["toolchains": [ "GCC_ARM"], "raas": "https://ruka.mbedcloudtesting.com:443"],
+  "DISCO_F769NI":   ["toolchains": [ "GCC_ARM"], "raas": "https://rauni.mbedcloudtesting.com:443"],
 ]
 
 for (target in smoke_test_config.keySet()) {

--- a/TESTS/smoke/configs.md
+++ b/TESTS/smoke/configs.md
@@ -10,6 +10,7 @@ Following table is parsed automatically by build scripts, so follow the format E
 |NUCLEO_F303RE|../../BUILD/mbed_app/NUCLEO_F303RE/GCC_ARM/mbed-bootloader.bin|0x8000|0x8400|0x40000|0x40070|
 |NUCLEO_F411RE|../../BUILD/mbed_app/NUCLEO_F411RE/GCC_ARM/mbed-bootloader.bin|0x8000|0x8400|0x40000|0x40070|
 |NUCLEO_F429ZI|../../BUILD/mbed_app/NUCLEO_F429ZI/GCC_ARM/mbed-bootloader.bin|0x8000|0x8400|0x100000|0x100070|
+|DISCO_F769NI|../../BUILD/mbed_app/DISCO_F769NI/GCC_ARM/mbed-bootloader.bin|0x40000|0x40400|0x100000|0x100070|
 
 
 ## Finding the values

--- a/configs/internal_flash_no_rot.json
+++ b/configs/internal_flash_no_rot.json
@@ -151,6 +151,14 @@
             "update-client.application-details"        : "(MBED_ROM_START + MBED_BOOTLOADER_SIZE + KVSTORE_SIZE)",
             "update-client.storage-address"            : "(MBED_ROM_START + MBED_BOOTLOADER_FLASH_BANK_SIZE)",
             "mbed-bootloader.max-application-size"     : "((1024-32-64)*1024)"
+        },
+        "DISCO_F769NI": {
+            "mbed-bootloader.bootloader-size"           : "(64*1024)",
+            "target.restrict_size"                      : "0x10000",
+            "update-client.application-details"         : "(MBED_ROM_START + 256*1024)",
+            "update-client.storage-address"             : "(MBED_ROM_START + MBED_BOOTLOADER_FLASH_BANK_SIZE)",
+            "kvstore-size"                              : "(2*32*1024)",
+            "storage_tdb_internal.internal_base_address": "(MBED_ROM_START+MBED_BOOTLOADER_SIZE)"
         }
     }
 }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -96,6 +96,12 @@
         },
         "NUCLEO_L073RZ": {
             "target.boot-stack-size"                   : "1024"
+        },
+        "DISCO_F769NI": {
+            "target.extra_labels_remove"       : [ "PSA" ],
+            "mbed-bootloader.bootloader-size"  : "(64*1024)",
+            "target.restrict_size"             : "0x10000",
+            "update-client.application-details": "(MBED_ROM_START + 256*1024)"
         }
     }
 }

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -56,7 +56,8 @@ targets = [
     ("NUCLEO_F411RE", "kvstore_and_fw_candidate_on_sd"),  # cloud client
     ("DISCO_L475VG_IOT01A", "internal_kvstore_with_qspif"),  # cloud client
     ("LPC55S69_NS", "psa"),  # cloud client
-    ("NUCLEO_F303RE", "internal_kvstore_with_spif")  # cloud client
+    ("NUCLEO_F303RE", "internal_kvstore_with_spif"),  # cloud client
+    ("DISCO_F769NI", "internal_flash_no_rot")
 ]
 toolchain = "GCC_ARM"
 profile = "release"  # default value, changed via command line arg --profile


### PR DESCRIPTION
Add support for DISCO_F769.
Bootloader built with `mbed_app.json` has been tested with the smoke-test application.
Bootloader built with `internal_flash_no_rot.json` has also been tested with the smoke-test application.