### PR TITLE
Provide alternate entry point for bootloader instead of main

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -22,6 +22,11 @@
             "value": 3,
             "macro_name": "MAX_BOOT_RETRIES"
         },
+        "nonstandard-entrypoint": {
+            "help": "Set to 1 to turn the Mbed Bootloader application into a library that can be ported to other platforms.",
+            "value": null,
+            "macro_name": "MBED_BOOTLOADER_NONSTANDARD_ENTRYPOINT"
+        },
         "show-serial-output": {
             "help": "Show boot status and progress on serial output. Disable output to save space on headless devices.",
             "value": 1,

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -40,7 +40,12 @@ const arm_uc_installer_details_t bootloader = {
     .layout   = BOOTLOADER_STORAGE_LAYOUT
 };
 
+#if defined(MBED_BOOTLOADER_NONSTANDARD_ENTRYPOINT)
+extern "C"
+int mbed_bootloader_entrypoint(void)
+#else
 int main(void)
+#endif
 {
     // this forces the linker to keep bootloader object now that it's not
     // printed anymore


### PR DESCRIPTION
Alternate entry point can be used for porting Mbed Bootloader to
native SDK builds, effectively turning it into a library.