### PR TITLE
[DISCO_L475VG_IOT01A] Every first boot after 2nd storage erase fails.…

### DIFF
--- a/source/upgrade.cpp
+++ b/source/upgrade.cpp
@@ -318,7 +318,7 @@ bool hwResetReason(void) {
 #if DEVICE_RESET_REASON
     reset_reason_t  reason = hal_reset_reason_get();
 
-    if(reason < RESET_REASON_SOFTWARE) {
+    if(reason < RESET_REASON_WATCHDOG) {
         return true;
     }
     else {


### PR DESCRIPTION
… Checked reset reson up to watchdog or higher.

Fix is up the reset reason to watchdog when checked to prevent boot loop. Software reason is now valid and doesn't increases failed boot counter.