### PR TITLE
Don't try to retarget console to serial.

### DIFF
--- a/configs/external_kvstore_with_qspif.json
+++ b/configs/external_kvstore_with_qspif.json
@@ -87,6 +87,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                              : "small",
             "platform.use-mpu"                          : false,
             "platform.default-serial-baud-rate"         : 115200,

--- a/configs/external_kvstore_with_spif.json
+++ b/configs/external_kvstore_with_spif.json
@@ -87,6 +87,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                              : "small",
             "platform.use-mpu"                          : false,
             "platform.default-serial-baud-rate"         : 115200,

--- a/configs/internal_flash_no_rot.json
+++ b/configs/internal_flash_no_rot.json
@@ -82,6 +82,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                             : "small",
             "platform.default-serial-baud-rate"        : 115200,
             "update-client.firmware-header-version"    : "2",

--- a/configs/internal_kvstore_with_qspif.json
+++ b/configs/internal_kvstore_with_qspif.json
@@ -82,6 +82,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                              : "small",
             "platform.use-mpu"                          : false,
             "platform.default-serial-baud-rate"         : 115200,

--- a/configs/internal_kvstore_with_sd.json
+++ b/configs/internal_kvstore_with_sd.json
@@ -83,6 +83,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                              : "small",
             "platform.use-mpu"                          : false,
             "platform.default-serial-baud-rate"         : 115200,

--- a/configs/internal_kvstore_with_spif.json
+++ b/configs/internal_kvstore_with_spif.json
@@ -83,6 +83,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                              : "small",
             "platform.use-mpu"                          : false,
             "platform.default-serial-baud-rate"         : 115200,

--- a/configs/kvstore_and_fw_candidate_on_sd.json
+++ b/configs/kvstore_and_fw_candidate_on_sd.json
@@ -75,6 +75,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                             : "small",
             "platform.use-mpu"                         : false,
             "platform.default-serial-baud-rate"        : 115200,

--- a/configs/psa.json
+++ b/configs/psa.json
@@ -73,6 +73,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                             : "small",
             "platform.use-mpu"                         : false,
             "platform.default-serial-baud-rate"        : 115200,

--- a/configs/spif_kvstore.json
+++ b/configs/spif_kvstore.json
@@ -56,6 +56,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                             : "small",
             "platform.use-mpu"                         : false,
             "platform.default-serial-baud-rate"        : 115200,

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -69,6 +69,7 @@
     ],
     "target_overrides": {
         "*": {
+            "target.console-uart"                      : false,
             "target.c_lib"                             : "small",
             "platform.use-mpu"                         : false,
             "platform.default-serial-baud-rate"        : 115200,


### PR DESCRIPTION
In bootloader, we have already dropped a support for formatted prints.
Therefore targeting console to serial just brings in extra code that
never gets called.
Configure all targets to target console to dummy Sink device which
is smaller in code size.