### PR TITLE
Drops support for UBLOX_ODIN_W2 and temporarily disables LPC55S69_NS

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,3 +1,0 @@
-mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/default_wifi_interface.cpp
-mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,8 @@ def build_test_config = [
   ["NUCLEO_F429ZI",       "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["NUCLEO_F411RE",       "configs/kvstore_and_fw_candidate_on_sd.json", "GCC_ARM"],
   ["DISCO_L475VG_IOT01A", "configs/internal_kvstore_with_qspif.json",    "GCC_ARM"],
-  ["LPC55S69_NS",         "configs/psa.json",                            "GCC_ARM"],
+  // LPC55S69_NS is disabled for now in mbed-os
+  //["LPC55S69_NS",         "configs/psa.json",                            "GCC_ARM"],
   ["NUCLEO_F303RE",       "configs/internal_kvstore_with_spif.json",     "GCC_ARM"],
   ["DISCO_F769NI",        "configs/internal_flash_no_rot.json",          "GCC_ARM"],
 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,6 @@ def build_test_config = [
   ["NRF52840_DK",         "configs/internal_kvstore_with_qspif.json",    "GCC_ARM"],
   ["NUCLEO_L4R5ZI",       "configs/internal_flash_no_rot.json",          "GCC_ARM"],
   ["NUCLEO_F429ZI",       "configs/internal_flash_no_rot.json",          "GCC_ARM"],
-  ["UBLOX_EVK_ODIN_W2",   "configs/internal_kvstore_with_sd.json",       "GCC_ARM"],
   ["NUCLEO_F411RE",       "configs/kvstore_and_fw_candidate_on_sd.json", "GCC_ARM"],
   ["DISCO_L475VG_IOT01A", "configs/internal_kvstore_with_qspif.json",    "GCC_ARM"],
   ["LPC55S69_NS",         "configs/psa.json",                            "GCC_ARM"],

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In order for the cloud client to recognise this struct and obtain the informatio
 
 1. Example python code for obtaining the location:
     ```python
-    with open("BUILD/UBLOX_EVK_ODIN_W2/GCC_ARM/mbed-bootloader.map", 'r') as fd:
+    with open("BUILD/K64F/GCC_ARM/mbed-bootloader.map", 'r') as fd:
         s = fd.read()
 
     regex = r"\.rodata\..*{}\s+(0x[0-9a-fA-F]+)".format("bootloader")

--- a/configs/internal_kvstore_with_sd.json
+++ b/configs/internal_kvstore_with_sd.json
@@ -104,9 +104,6 @@
         "K64F": {
             "target.extra_labels_remove"                : [ "PSA" ]
         },
-        "UBLOX_EVK_ODIN_W2": {
-            "target.extra_labels_remove"                : [ "PSA" ]
-        },
         "K66F": {
             "target.extra_labels_remove"                : [ "PSA" ]
         },

--- a/configs/kvstore_and_fw_candidate_on_sd.json
+++ b/configs/kvstore_and_fw_candidate_on_sd.json
@@ -136,11 +136,6 @@
             "mbed-bootloader.bootloader-size"          : "(34*1024)",
             "target.boot-stack-size"                   : "1024"
         },
-        "UBLOX_EVK_ODIN_W2": {
-            "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
-            "target.device_has_remove"                 : [ "LPTICKER" ],
-            "target.extra_labels_remove"               : [ "PSA"]
-        },
         "UBLOX_C030_U201": {
             "storage_filesystem.rbp_internal_size"     : "(2*16*1024)",
             "target.device_has_remove"                 : [ "LPTICKER" ]

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -54,7 +54,8 @@ targets = [
     ("NRF52840_DK", "internal_kvstore_with_qspif"),
     ("NUCLEO_F411RE", "kvstore_and_fw_candidate_on_sd"),  # cloud client
     ("DISCO_L475VG_IOT01A", "internal_kvstore_with_qspif"),  # cloud client
-    ("LPC55S69_NS", "psa"),  # cloud client
+    # LPC55S69_NS is disabled for now in mbed-os
+    #("LPC55S69_NS", "psa"),  # cloud client
     ("NUCLEO_F303RE", "internal_kvstore_with_spif"),  # cloud client
     ("DISCO_F769NI", "internal_flash_no_rot")
 ]

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -51,7 +51,6 @@ targets = [
     ("K66F", "internal_flash_no_rot"),  # cloud client
     ("NUCLEO_L4R5ZI", "internal_flash_no_rot"),  # cloud client
     ("NUCLEO_F429ZI", "internal_flash_no_rot"),  # cloud client
-    ("UBLOX_EVK_ODIN_W2", "internal_kvstore_with_sd"),  # cloud client
     ("NRF52840_DK", "internal_kvstore_with_qspif"),
     ("NUCLEO_F411RE", "kvstore_and_fw_candidate_on_sd"),  # cloud client
     ("DISCO_L475VG_IOT01A", "internal_kvstore_with_qspif"),  # cloud client


### PR DESCRIPTION
Mbed OS 5.15 was the last release which supported the UBLOX_ODIN_W2.
Master branch of mbed-os has currently disabled the LPC55S69_NS.