### PR TITLE
Trace size reduction

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -18,9 +18,9 @@
             "value": "DEFAULT_MAX_APPLICATION_SIZE"
         },
         "trace": {
-            "help": "Show boot status and progress on serial output. Disable output to save space on headless devices.",
-            "value": true,
-            "macro_name": "MBED_BOOTLOADER_TRACE"
+            "help": "Show boot status and progress on serial output. Use USE_DIRECT_SERIAL_OUTPUT to save space.",
+            "accepted_values": ["USE_PRINTF", "USE_DIRECT_SERIAL_OUTPUT"],
+            "value": "USE_DIRECT_SERIAL_OUTPUT"
         },
         "default-max-application-size":{
             "help": "The max application size",

--- a/presets/TARGET_K64F/TARGET_BL_SD/mbed_app.json
+++ b/presets/TARGET_K64F/TARGET_BL_SD/mbed_app.json
@@ -70,6 +70,7 @@
             "target.console-uart"                      : true,
             "target.c_lib"                             : "small",
             "platform.use-mpu"                         : false,
+            "platform.stdio-flush-at-exit"             : false,
             "platform.stdio-baud-rate"                 : 115200,
             "fota.is-bootloader"                       : true,
             "target.header_format": [

--- a/presets/TARGET_NUCLEO_F411RE/TARGET_BL_SD/mbed_app.json
+++ b/presets/TARGET_NUCLEO_F411RE/TARGET_BL_SD/mbed_app.json
@@ -68,10 +68,11 @@
     ],
     "target_overrides": {
         "*": {
-            "target.console-uart"                      : false,
+            "target.console-uart"                      : true,
             "target.c_lib"                             : "small",
             "platform.use-mpu"                         : false,
             "platform.stdio-baud-rate"                 : 115200,
+            "platform.stdio-flush-at-exit"             : false,
             "fota.is-bootloader"                       : true,
             "target.header_format": [
                 ["magic", "const", "32le", "0x5c0253a3"],

--- a/source/mbed-trace/direct_serial_output.c
+++ b/source/mbed-trace/direct_serial_output.c
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------
+// Copyright 2020 ARM Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------
+
+#include "direct_serial_output.h"
+#include "hal/serial_api.h"
+
+#if (MBED_CONF_MBED_BOOTLOADER_TRACE == USE_DIRECT_SERIAL_OUTPUT)
+
+static serial_t uart = {};
+
+/* module variable for keeping track of initialization */
+static bool not_initialized = true;
+
+/**
+ * @brief Initialization serial port if needed.
+ *.
+ */
+static void direct_serial_output_init()
+{
+    if (not_initialized)
+    {
+        not_initialized = false;
+
+        serial_init(&uart, STDIO_UART_TX, STDIO_UART_RX);
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+        serial_baud(&uart, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
+#endif
+    }
+}
+
+/**
+ * @brief Function that directly outputs to serial port in blocking mode.
+ *
+ * @param string outputed to serial port.
+ */
+void direct_serial_output_process(const char *s)
+{
+    direct_serial_output_init();
+
+    while(*s) {
+        serial_putc(&uart, *s);
+        s++;
+    }
+}
+
+#endif // MBED_BOOTLOADER_USE_DIRECT_SERIAL_OUTPUT
+

--- a/source/mbed-trace/direct_serial_output.c
+++ b/source/mbed-trace/direct_serial_output.c
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright 2020 ARM Ltd.
+// Copyright 2020 Pelion Ltd.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,13 +18,46 @@
 
 #include "direct_serial_output.h"
 #include "hal/serial_api.h"
+#include <stdio.h>
+#include <stdarg.h>	
 
 #if (MBED_CONF_MBED_BOOTLOADER_TRACE == USE_DIRECT_SERIAL_OUTPUT)
 
+# define MAX_STRING_REPRESENTATION_SIZE 20
+
 static serial_t uart = {};
 
-/* module variable for keeping track of initialization */
-static bool not_initialized = true;
+static bool initialized = false;
+
+//format specifier list.
+
+/*Currently suported specifies: {'c','d','u','s','x','X',i'} */
+static char format_specifiers[] = {'c','d','u','s','x','X','i','e','E','f','g','G','o','p','n','z'};
+static char hex_representation[]= "0123456789ABCDEF";
+static char num_string_buff[MAX_STRING_REPRESENTATION_SIZE]; 
+
+static char* convert_to_string(unsigned int num, int base) 
+{ 
+    char *ptr = &num_string_buff[MAX_STRING_REPRESENTATION_SIZE-1];
+    *ptr = '\0';  
+    do 
+    { 
+        ptr--;
+        *ptr = hex_representation[num % base]; 
+        num /= base; 
+    } while (num != 0);
+    
+    return(ptr); 
+}
+
+
+static void output_string_to_serial(const char *str) 
+{
+    while (*str) {
+      serial_putc(&uart, *str);
+      str++;
+    }
+}
 
 /**
  * @brief Initialization serial port if needed.
@@ -32,30 +65,107 @@ static bool not_initialized = true;
  */
 static void direct_serial_output_init()
 {
-    if (not_initialized)
+    if (initialized == false)
     {
-        not_initialized = false;
-
         serial_init(&uart, STDIO_UART_TX, STDIO_UART_RX);
 #if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
         serial_baud(&uart, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
 #endif
+
+        initialized = true;
     }
 }
+
 
 /**
  * @brief Function that directly outputs to serial port in blocking mode.
  *
  * @param string outputed to serial port.
  */
-void direct_serial_output_process(const char *s)
+void direct_serial_output_process(const char *format, ...)
 {
+    char c, *str;
+    int i;
+    bool format_specifier_detected = false;
+
     direct_serial_output_init();
 
-    while(*s) {
-        serial_putc(&uart, *s);
-        s++;
+    va_list arg;
+    va_start (arg, format);
+
+    while (*format) {
+
+        if (*format == '%') { // required format identifer char
+
+            //find the argument in the argument array. It doensn't have to be necessary the next char (i.e %llu)
+            while ((format_specifier_detected == false) && (*format)) {
+                format++;
+                for (size_t j = 0; j < sizeof(format_specifiers); j++) {
+                    if ((*format) == format_specifiers[j]) {
+                        format_specifier_detected = true;
+                        break;
+                    }
+                }
+            }
+
+            if (format_specifier_detected == true) {
+
+                //format identifier detected, process it
+                switch (*format) {
+                    case 'c': //process single character
+                        c = va_arg(arg, int);
+                        serial_putc(&uart, c);
+                        break;
+
+                    case 'i':
+                    case 'd':  //process integer
+                        i = va_arg(arg, int );
+                        if(i < 0) 
+                        { 
+                            i = -i;
+                            serial_putc(&uart,'-');
+                        } 
+                        str = convert_to_string(i, 10);
+                        output_string_to_serial(str);
+                        break;
+
+                    case 'u': //process unsigned integer
+                        str = convert_to_string(va_arg(arg, unsigned int ), 10);
+                        output_string_to_serial(str);
+                        break;
+
+                    case 's': //process string
+                        str = va_arg(arg,char*); //Fetch string
+                        output_string_to_serial(str);
+                        break; 
+
+                    case 'x': //process hex format
+                    case 'X':
+                        str = convert_to_string(va_arg(arg,unsigned int),16);
+                        output_string_to_serial(str);
+                        break;
+
+                    default: //unsupported specifier, just fetch it
+                        va_arg(arg, int); 
+                        break;
+                } 
+
+                format_specifier_detected = false;
+
+            } else {
+                //reached NULL character after % without specifier. stop processing.
+                goto finish;
+            }
+
+        } else {
+            serial_putc(&uart, *format);
+        }
+
+        format++;
     }
+
+finish:
+    va_end(arg);
 }
 
 #endif // MBED_BOOTLOADER_USE_DIRECT_SERIAL_OUTPUT

--- a/source/mbed-trace/direct_serial_output.h
+++ b/source/mbed-trace/direct_serial_output.h
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------------------
+// Copyright 2020 ARM Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------
+
+#ifndef DIRECT_SERIAL_OUTPUT_H
+#define DIRECT_SERIAL_OUTPUT_H
+
+#include <stdint.h>
+
+#define USE_PRINTF 5555
+#define USE_DIRECT_SERIAL_OUTPUT 5556
+
+#if (MBED_CONF_MBED_BOOTLOADER_TRACE == USE_DIRECT_SERIAL_OUTPUT)
+void direct_serial_output_process(const char *s);
+#endif
+
+#endif // DIRECT_SERIAL_OUTPUT_H

--- a/source/mbed-trace/direct_serial_output.h
+++ b/source/mbed-trace/direct_serial_output.h
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright 2020 ARM Ltd.
+// Copyright 2020 Pelion Ltd.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -25,7 +25,17 @@
 #define USE_DIRECT_SERIAL_OUTPUT 5556
 
 #if (MBED_CONF_MBED_BOOTLOADER_TRACE == USE_DIRECT_SERIAL_OUTPUT)
-void direct_serial_output_process(const char *s);
+
+#ifdef __cplusplus
+extern "C" {
 #endif
+
+void direct_serial_output_process(const char *format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // (MBED_CONF_MBED_BOOTLOADER_TRACE == USE_DIRECT_SERIAL_OUTPUT)
 
 #endif // DIRECT_SERIAL_OUTPUT_H

--- a/source/mbed-trace/mbed_trace.h
+++ b/source/mbed-trace/mbed_trace.h
@@ -22,6 +22,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
+#include "direct_serial_output.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,8 +36,8 @@ extern "C" {
 #undef tr_trace
 #undef tr_flush
 
-#if MBED_BOOTLOADER_TRACE
 
+#if (MBED_CONF_MBED_BOOTLOADER_TRACE == USE_PRINTF)
 #if MBED_BOOTLOADER_DEBUG_PRINTS_ENABLED
 #define pr_debug(fmt, ...)   printf("[DBG ] " fmt "\r\n", ##__VA_ARGS__)
 #else
@@ -55,13 +56,18 @@ extern "C" {
 
 #else
 #define pr_debug(...)
-#define pr_info(...)
-#define pr_warning(...)
-#define pr_warn(...)
-#define pr_error(...)
-#define pr_trace(...)
-#define pr_flush(...)
-#endif // !MBED_BOOTLOADER_TRACE
+
+#define pr_info(fmt, ...)    direct_serial_output_process("[BOOT] " fmt "\r\n")
+
+#define pr_warning(fmt, ...) direct_serial_output_process("[WARN] " fmt "\r\n")
+
+#define pr_error(fmt, ...)   direct_serial_output_process("[ERR ] " fmt "\r\n")
+
+#define pr_trace(fmt, ...)   direct_serial_output_process(fmt)
+
+#define pr_flush(x)
+
+#endif
 
 #if MBED_BOOTLOADER_EXTERNAL_TRACES_ENABLED
 #define tr_debug    pr_debug

--- a/source/mbed-trace/mbed_trace.h
+++ b/source/mbed-trace/mbed_trace.h
@@ -57,13 +57,13 @@ extern "C" {
 #else
 #define pr_debug(...)
 
-#define pr_info(fmt, ...)    direct_serial_output_process("[BOOT] " fmt "\r\n")
+#define pr_info(fmt, ...)    direct_serial_output_process("[BOOT] " fmt "\r\n", ##__VA_ARGS__)
 
-#define pr_warning(fmt, ...) direct_serial_output_process("[WARN] " fmt "\r\n")
+#define pr_warning(fmt, ...) direct_serial_output_process("[WARN] " fmt "\r\n", ##__VA_ARGS__)
 
-#define pr_error(fmt, ...)   direct_serial_output_process("[ERR ] " fmt "\r\n")
+#define pr_error(fmt, ...)   direct_serial_output_process("[ERR ] " fmt "\r\n", ##__VA_ARGS__)
 
-#define pr_trace(fmt, ...)   direct_serial_output_process(fmt)
+#define pr_trace(fmt, ...)   direct_serial_output_process(fmt), ##__VA_ARGS__)
 
 #define pr_flush(x)
 


### PR DESCRIPTION
Reduce size of traces in bootloaders in order to reduce overall bootloader application size.
The idea is to redirect traces directly to serial by implementing a thin driver (similar to UC bootloaders) and avoid the overhead of mbed-os and standard c library when using `printf`.
If `USE_DIRECT_SERIAL_OUTPUT` flag set - traces redirected directly to serial.
If `USE_PRINTF` flag set- printf used for traces.
default configuration is `USE_DIRECT_SERIAL_OUTPUT`.

For bootloaders that configured with external storage (and are bigger), disabling `fflush` saves additional space (up to 2 KB) 

 