### PR TITLE
add key derivation to k64f sd

### DIFF
--- a/presets/TARGET_K64F/TARGET_BL_SD/mbed_app.json
+++ b/presets/TARGET_K64F/TARGET_BL_SD/mbed_app.json
@@ -63,7 +63,8 @@
     "macros": [
         "MBED_CLOUD_CLIENT_FOTA_FW_HEADER_VERSION=3",
         "FOTA_HEADER_HAS_CANDIDATE_READY=1",        
-        "MBED_CLOUD_CLIENT_FOTA_ENABLE=1"
+        "MBED_CLOUD_CLIENT_FOTA_ENABLE=1",
+        "FOTA_KEY_FORCE_DERIVATION=1"
     ],
     "target_overrides": {
         "*": {

--- a/presets/TARGET_K64F/TARGET_BL_SD/mbed_lib.json.template
+++ b/presets/TARGET_K64F/TARGET_BL_SD/mbed_lib.json.template
@@ -4,6 +4,7 @@
         "*": {{
             "target.macros_add": [
                 "FOTA_USE_DEVICE_KEY",
+                "FOTA_KEY_FORCE_DERIVATION=(1)",
                 "MBED_CONF_STORAGE_STORAGE_TYPE=FILESYSTEM",
                 "MBED_CONF_STORAGE_FILESYSTEM_FILESYSTEM=LITTLE",
                 "MBED_CONF_STORAGE_FILESYSTEM_BLOCKDEVICE=SD",


### PR DESCRIPTION
enable key derivation for K64F SD - 144 byte oversize.
had to cut some "wording" at upgrade.c to make it suit 32k
