### PR TITLE
Added mbed_bootloader_entrypoint() 

### DIFF
--- a/fota/fota_component.c
+++ b/fota/fota_component.c
@@ -136,7 +136,7 @@ void fota_component_get_desc(unsigned int comp_id, const fota_component_desc_t *
     comp_id_translate(&comp_id, &comp_table, &num_components);
 #endif
 
-    FOTA_ASSERT(comp_id < num_components)
+    FOTA_ASSERT(comp_id < num_components);
     *comp_desc = &comp_table[comp_id];
 }
 
@@ -148,7 +148,7 @@ void fota_component_get_curr_version(unsigned int comp_id, fota_component_versio
 #ifdef FOTA_INTERNAL_COMPONENTS_SUPPORT
     comp_id_translate(&comp_id, &comp_table, &num_components);
 #endif
-    FOTA_ASSERT(comp_id < num_components)
+    FOTA_ASSERT(comp_id < num_components);
     *version = comp_table[comp_id].version;
 }
 
@@ -160,7 +160,7 @@ void fota_component_set_curr_version(unsigned int comp_id, fota_component_versio
 #ifdef FOTA_INTERNAL_COMPONENTS_SUPPORT
     comp_id_translate(&comp_id, &comp_table, &num_components);
 #endif
-    FOTA_ASSERT(comp_id < num_components)
+    FOTA_ASSERT(comp_id < num_components);
     comp_table[comp_id].version = version;
 }
 

--- a/fota/fota_crypto.c
+++ b/fota/fota_crypto.c
@@ -557,7 +557,13 @@ int fota_verify_signature_prehashed(
 
     mbedtls_x509_crt_init(&crt);
 
+/*mbedtls_x509_crt_parse_der_nocopy not supported for mbedtls 2.16.0 and lower versions,
+ use older version of x509 cert parse function */
+#if  (MBEDTLS_VERSION_NUMBER < 0x02110000)
+    ret = mbedtls_x509_crt_parse_der(
+#else
     ret = mbedtls_x509_crt_parse_der_nocopy(
+#endif
               &crt,
               update_crt_data, update_crt_size
           );

--- a/fota/import_ref.txt
+++ b/fota/import_ref.txt
@@ -1,1 +1,1 @@
-Imported from mbed-cloud-client-internal at hash: 0858c25ae4ef8f3243dad08a11941e3862317f8f
+Imported from mbed-cloud-client-internal at hash: f39aff46a5d8c4c9f4def0bc288beb85a3e695c2

--- a/upgrade.c
+++ b/upgrade.c
@@ -344,7 +344,11 @@ MBED_NORETURN void mbed_die(void)
     }
 }
 
+#if defined(MBED_BOOTLOADER_NONSTANDARD_ENTRYPOINT)
+int mbed_bootloader_entrypoint(void)
+#else
 int main(void)
+#endif
 {
     bool is_new_firmware = false;
     pr_cmd("Build at: " __DATE__ " " __TIME__);


### PR DESCRIPTION
I. Added mbed_bootloader_entrypoint() to support bootloader for LPCXpresso546XX board.

II. Fota synced changes:

1. For mbedtls 2.16.0 and lower version use older version of x509 cert parse function.
mbedtls_x509_crt_parse_der_nocopy supported from 2.17.0 and up
f39aff46a5d8c4c9f4def0bc288beb85a3e695c2

2. fota: add missing semicolon to few users of FOTA_ASSERT()
ad4c66173da49f83bdb71f7b6549a1c8aea98f2c

3. fix defer/resume doxygen
743941effd017a945a1713a6c7a1d8ce6fd5cead

4. Added comments to set_full_file_name function.
6f7eaea4f420967339ce6d47721f8e120a408cb5
