### PR TITLE
Define MBEDTLS_BIGNUM_C for mbedtls  2.16.0 and lower

### DIFF
--- a/source/bootloader_mbedtls_user_config.h
+++ b/source/bootloader_mbedtls_user_config.h
@@ -168,7 +168,12 @@
 #undef MBEDTLS_ASN1_PARSE_C
 #undef MBEDTLS_ASN1_WRITE_C
 #undef MBEDTLS_BASE64_C
+//For mbedtls 2.16.0 and lower version, fota bootloader with external storage requiers MBEDTLS_BIG_NUM_C define 
+#if  (MBEDTLS_VERSION_NUMBER < 0x02110000)
+#define MBEDTLS_BIGNUM_C
+#else
 #undef MBEDTLS_BIGNUM_C
+#endif
 #undef MBEDTLS_CERTS_C
 #undef MBEDTLS_CRC_C
 #undef MBEDTLS_GCM_C


### PR DESCRIPTION
Lower versions of mbedtls requires MBEDTLS_BUGNUM_C for external fota storage flow.
Added for nxp lpc54 bootloader compilation where SDK uses mbedtls 2.16.0 